### PR TITLE
:bug: fix user selected clock when no groups

### DIFF
--- a/src/features/infopanel/addClockButton.tsx
+++ b/src/features/infopanel/addClockButton.tsx
@@ -20,8 +20,12 @@ export function AddClockButton () {
         let groupings: string[] = tipNames.map((name) => {
             if (selectedIds.includes(name)) {
                 return "User Selected"
-            } 
-            return tipData[name].group
+            } else if (tipData[name].group !== undefined){
+                return tipData[name].group
+            } else {
+                return "Background"
+            }
+         
         })
         
         let decimal_dates: number[] = tipNames.map((name) => {

--- a/src/features/regression/components/tipLabelForm.tsx
+++ b/src/features/regression/components/tipLabelForm.tsx
@@ -18,14 +18,10 @@ export function TipLabelForm(props: any) {
     })
   
     let groupings: string[]
-    if (group) {
-      groupings = props.tipNames.map((name: string) => {
-        return extractPartOfTipName(name, delimiter, group)
-      })
-    } else {
-      groupings = props.tipNames.map(() => "none")
-    }
-  
+    groupings = props.tipNames.map((name: string) => {
+      return group !== undefined ? extractPartOfTipName(name, delimiter, group) : "Background"
+    })
+
     const handleSubmit = (event: any) => {
       event.preventDefault();
       props.onSubmit(decimal_dates, groupings)


### PR DESCRIPTION
I get this warning in the console. Can you enlighten me a little please @Wytamma . No rush here - I'm keen to pull this change but don't want to make another bug!

Warning: You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.